### PR TITLE
Support projects with a single page of issues

### DIFF
--- a/lib/locker.rb
+++ b/lib/locker.rb
@@ -61,7 +61,7 @@ class Locker
       issues += new_issues
 
       # Pagination
-      if resp['Link'].match /<https:\/\/api\.github\.com(\/[^>]+)>; rel="next",/
+      if resp['Link'] and resp['Link'].match /<https:\/\/api\.github\.com(\/[^>]+)>; rel="next",/
         path = $1
         page = path.match(/page=(\d+)/)[1]
       else


### PR DESCRIPTION
The API response does not have a `Link` header pointing to the next page.