### PR TITLE
Use the Authorization HTTP header instead of access_token

### DIFF
--- a/lib/locker.rb
+++ b/lib/locker.rb
@@ -44,14 +44,16 @@ class Locker
   # Fetches all closed, unlocked issues closed before cutoff date
   def get_closed_issues
     issues = []
-    path = "/repos/#@user/#@repo/issues?state=closed&access_token=#@token&sort=updated&direction=asc"
+    path = "/repos/#@user/#@repo/issues?state=closed&sort=updated&direction=asc"
     page = 1
+    headers = {'Authorization' => "Basic #{Base64.strict_encode64("#@user:#@token")}"}
+
     http = Net::HTTP.start("api.github.com", 443, nil, nil, nil, nil, use_ssl: true)
 
     loop do
       notify "Retrieving page #{page}..."
 
-      resp = http.get(path)
+      resp = http.get(path, headers)
       new_issues = JSON.parse(resp.body)
 
       unless Array === new_issues then


### PR DESCRIPTION
GitHub has deprecated support for tokens sent as a query parameter.

https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters

So, in `get_closed_issues`, use a HTTP authentication just like in `lock_old_closed_issues`.